### PR TITLE
[FIX]Deprecated: Optional parameter $coarseness declared before required parameter $context is implicitly treated as a required parameter,

### DIFF
--- a/src/Grammars/Availability/AvailabilityGrammar.php
+++ b/src/Grammars/Availability/AvailabilityGrammar.php
@@ -45,7 +45,7 @@ class AvailabilityGrammar extends Generator
     // ranges is an array from dow to tuple start-time, end-time (earliest start and end of
     // meetings for that day),
     // coarseness is one of the above constant.
-    public function generateAvailability($busyList, $ranges, $coarseness=self::BASE, $context)
+    public function generateAvailability($busyList, $ranges, $context, $coarseness=self::BASE)
     {
         return $this->generate([ 'busyList' => $busyList, 'ranges' => $ranges, 'coarseness' => $coarseness ], $context);
     }


### PR DESCRIPTION
**Change the order of the parameters in the method signature so that required parameters come before optional ones**
This is related to php-nlgen library which is causing error since PHP 8.0 where a required parameter $context comes before the optional parameter $coarseness as you can find here: [https://php.watch/versions/8.0](https://php.watch/versions/8.0/deprecate-required-param-after-optional).