### PR TITLE
[UPDATE] README.md: In Example section: last given line echo there we…

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $fullRanges = [];
 foreach(range(0, 6) as $dow) {
  $fullRanges[$dow] = [ [6, 0], [24, 0] ];
 }
-echp $gen->generateAvailability($busyList, $this->fullRanges, AvailabilityGenerator::BASE, null);
+echo $gen->generateAvailability($busyList, $fullRanges, AvailabilityGenerator::BASE, null);
 ```
 
 Produces _All week is mostly free all day. Sunday is busy from late 6 AM to late 11 AM, and from half past 14 PM to 22 PM; the rest is free._


### PR DESCRIPTION
In Example section: last given line **echo** there were **echp** and the use of **$this->$fullRanges** instead of  **$fullRanges** prints Fatal error: Uncaught Error: Using $this when not in object context .
**Consider** this pull request too: [https://github.com/DrDub/php-nlgen/pull/13](https://github.com/DrDub/php-nlgen/pull/13l).